### PR TITLE
Add favicon links and link styling to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,26 @@
 <html>
   <head>
     <title>yoge.sh</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
+    <link rel="manifest" href="/site.webmanifest">
+    <link rel="shortcut icon" href="/favicon.ico">
+    <style>
+      a {
+        color: #000;
+        text-decoration: none;
+      }
+      a:visited {
+        color: #000;
+      }
+      a:hover {
+        color: #555;
+        text-decoration: underline;
+      }
+    </style>
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- reference Android, Apple, and classic favicons in the HTML head
- style links black by default and underline with a lighter shade on hover

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c49ab7eb5c832d99afd954e2a81ad2