### PR TITLE
Modernize text-only landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,31 +1,46 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>yoge.sh</title>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
-    <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
-    <link rel="manifest" href="/site.webmanifest">
-    <link rel="shortcut icon" href="/favicon.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
     <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        font-family: 'Inter', sans-serif;
+        text-align: center;
+        color: #334155;
+        background-color: #fff;
+      }
+
       a {
-        color: #000;
+        color: #0ea5e9;
         text-decoration: none;
       }
-      a:visited {
-        color: #000;
-      }
-      a:hover {
-        color: #555;
+
+      a:hover,
+      a:focus {
+        color: #0284c7;
         text-decoration: underline;
       }
     </style>
   </head>
 
   <body>
-    <p>Yo, yo, yo.</p>
+    <h1>Yo, yo, yo.</h1>
     <p><a href="mailto:hi@yoge.sh">hi@yoge.sh</a></p>
     <p><a href="https://github.com/loop">github</a></p>
     <p><a href="https://linkedin.com/in/yogeshnagarur">linkedin</a></p>


### PR DESCRIPTION
## Summary
- Center content and enable responsive layout for simple landing page
- Use Google Fonts and update link colors for better readability

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c49cd90ffc832da10cd296f8127eab