### PR TITLE
Disable scrolling and add responsive text sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,14 @@
     <link rel="shortcut icon" href="/favicon.ico" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
     <style>
+      html,
       body {
         margin: 0;
-        min-height: 100vh;
+        height: 100%;
+        overflow: hidden;
+      }
+
+      body {
         display: flex;
         flex-direction: column;
         justify-content: center;
@@ -24,6 +29,16 @@
         text-align: center;
         color: #334155;
         background-color: #fff;
+      }
+
+      h1 {
+        font-size: clamp(2rem, 8vw, 4rem);
+        margin: 0.5em 0;
+      }
+
+      p {
+        font-size: clamp(1rem, 4vw, 1.5rem);
+        margin: 0.25em 0;
       }
 
       a {


### PR DESCRIPTION
## Summary
- prevent page scrolling across devices and center content
- scale heading and paragraph text with viewport size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5091ba644832dba2032a18eef8415