### PR TITLE
Disable pinch zoom on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <title>yoge.sh</title>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
@@ -52,6 +55,11 @@
         text-decoration: underline;
       }
     </style>
+    <script>
+      document.addEventListener('gesturestart', (e) => e.preventDefault(), {
+        passive: false,
+      });
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- prevent touch zooming by limiting viewport scale and disabling user scaling
- cancel `gesturestart` events to block pinch gestures on iOS Safari

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c509ea9268832d9a951cfc700ef84d